### PR TITLE
Fix search and dark mode improvements

### DIFF
--- a/src/components/AttachmentsModal.jsx
+++ b/src/components/AttachmentsModal.jsx
@@ -60,7 +60,7 @@ const AttachmentsModal = ({ docId, onClose }) => {
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-            <div className="bg-white rounded-xl p-6 w-full max-w-lg shadow-xl relative">
+            <div className="bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded-xl p-6 w-full max-w-lg shadow-xl relative">
                 <button onClick={onClose} className="absolute top-3 right-3 text-lg text-gray-400 hover:text-red-500">✕</button>
                 <h2 className="text-xl font-semibold mb-4">{t("attachments")}</h2>
 
@@ -79,7 +79,7 @@ const AttachmentsModal = ({ docId, onClose }) => {
                     >
                         {t("choose_file") || "Выбрать файл"}
                     </button>
-                    <span className="text-sm text-gray-700">
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
                         {selectedFile ? selectedFile.name : t("no_file_chosen") || "Файл не выбран"}
                     </span>
                     <button
@@ -95,11 +95,11 @@ const AttachmentsModal = ({ docId, onClose }) => {
                 {loading ? (
                     <div>{t("loading")}</div>
                 ) : (
-                    <ul className="divide-y">
-                        {attachments.length === 0 && <li className="text-gray-500">{t("no_attachments") || "Нет вложений"}</li>}
+                    <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+                        {attachments.length === 0 && <li className="text-gray-500 dark:text-gray-400">{t("no_attachments") || "Нет вложений"}</li>}
                         {attachments.map(att => (
                             <li key={att.id} className="flex justify-between items-center py-2">
-                                <span className="truncate max-w-xs">{att.filename}</span>
+                                <span className="truncate max-w-xs text-gray-900 dark:text-gray-100">{att.filename}</span>
                                 <div className="flex gap-3">
                                     <button
                                         onClick={() => handleDownload(att.id, att.filename)}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { getAllDocuments, searchDocuments } from "../services/api";
+import { searchDocuments } from "../services/api";
 import DocumentList from "../components/DocumentList";
 
 const FACULTY_KEYS = [
@@ -32,7 +32,7 @@ const SearchPage = () => {
     useEffect(() => {
         const fetchAll = async () => {
             try {
-                const res = await getAllDocuments();
+                const res = await searchDocuments({});
                 setResults(res.data);
             } catch (err) {
                 console.error("Ошибка загрузки документов:", err);

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: './'
 })


### PR DESCRIPTION
## Summary
- load search page data from open search endpoint
- add dark theme styling to attachments modal
- set base path in Vite config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b01bf8d88322be74a72dc2baada1